### PR TITLE
[i18n] gcc -print-search-dirs

### DIFF
--- a/libbuild2/cc/gcc.cxx
+++ b/libbuild2/cc/gcc.cxx
@@ -170,7 +170,7 @@ namespace build2
       cstrings args;
       string std; // Storage.
 
-      args.push_back ("(LANG=\"en_US\";");
+      args.push_back ("LC_ALL=C ");
       args.push_back (xc.recall_string ());
       append_options (args, rs, c_coptions);
       append_options (args, rs, x_coptions);
@@ -178,7 +178,6 @@ namespace build2
       append_options (args, rs, c_loptions);
       append_options (args, rs, x_loptions);
       args.push_back ("-print-search-dirs");
-      args.push_back (")");
       args.push_back (nullptr);
 
       if (verb >= 3)

--- a/libbuild2/cc/gcc.cxx
+++ b/libbuild2/cc/gcc.cxx
@@ -170,6 +170,7 @@ namespace build2
       cstrings args;
       string std; // Storage.
 
+      args.push_back ("(LANG=\"en_US\";");
       args.push_back (xc.recall_string ());
       append_options (args, rs, c_coptions);
       append_options (args, rs, x_coptions);
@@ -177,6 +178,7 @@ namespace build2
       append_options (args, rs, c_loptions);
       append_options (args, rs, x_loptions);
       args.push_back ("-print-search-dirs");
+      args.push_back (")");
       args.push_back (nullptr);
 
       if (verb >= 3)


### PR DESCRIPTION
When the shell isn't in English, it can't locate to the library infos by finding `libraries: =`.
So add a `LANG="en_US"` before the `gcc` command and fix it.