### PR TITLE
Replace dynamic exception specification remains with noexcept.

### DIFF
--- a/libbuild2/common-options.cxx
+++ b/libbuild2/common-options.cxx
@@ -30,7 +30,7 @@ namespace build2
       // unknown_option
       //
       unknown_option::
-      ~unknown_option () throw ()
+      ~unknown_option () noexcept
       {
       }
 
@@ -41,7 +41,7 @@ namespace build2
       }
 
       const char* unknown_option::
-      what () const throw ()
+      what () const noexcept
       {
         return "unknown option";
       }
@@ -49,7 +49,7 @@ namespace build2
       // unknown_argument
       //
       unknown_argument::
-      ~unknown_argument () throw ()
+      ~unknown_argument () noexcept
       {
       }
 
@@ -60,7 +60,7 @@ namespace build2
       }
 
       const char* unknown_argument::
-      what () const throw ()
+      what () const noexcept
       {
         return "unknown argument";
       }
@@ -68,7 +68,7 @@ namespace build2
       // missing_value
       //
       missing_value::
-      ~missing_value () throw ()
+      ~missing_value () noexcept
       {
       }
 
@@ -79,7 +79,7 @@ namespace build2
       }
 
       const char* missing_value::
-      what () const throw ()
+      what () const noexcept
       {
         return "missing option value";
       }
@@ -87,7 +87,7 @@ namespace build2
       // invalid_value
       //
       invalid_value::
-      ~invalid_value () throw ()
+      ~invalid_value () noexcept
       {
       }
 
@@ -102,7 +102,7 @@ namespace build2
       }
 
       const char* invalid_value::
-      what () const throw ()
+      what () const noexcept
       {
         return "invalid option value";
       }
@@ -116,7 +116,7 @@ namespace build2
       }
 
       const char* eos_reached::
-      what () const throw ()
+      what () const noexcept
       {
         return "end of argument stream reached";
       }
@@ -124,7 +124,7 @@ namespace build2
       // file_io_failure
       //
       file_io_failure::
-      ~file_io_failure () throw ()
+      ~file_io_failure () noexcept
       {
       }
 
@@ -135,7 +135,7 @@ namespace build2
       }
 
       const char* file_io_failure::
-      what () const throw ()
+      what () const noexcept
       {
         return "unable to open file or read failure";
       }
@@ -143,7 +143,7 @@ namespace build2
       // unmatched_quote
       //
       unmatched_quote::
-      ~unmatched_quote () throw ()
+      ~unmatched_quote () noexcept
       {
       }
 
@@ -154,7 +154,7 @@ namespace build2
       }
 
       const char* unmatched_quote::
-      what () const throw ()
+      what () const noexcept
       {
         return "unmatched quote";
       }

--- a/libbuild2/common-options.hxx
+++ b/libbuild2/common-options.hxx
@@ -47,7 +47,7 @@ namespace build2
 
         usage_para (value);
 
-        operator value () const 
+        operator value () const
         {
           return v_;
         }
@@ -68,7 +68,7 @@ namespace build2
 
         unknown_mode (value);
 
-        operator value () const 
+        operator value () const
         {
           return v_;
         }
@@ -94,7 +94,7 @@ namespace build2
       {
         public:
         virtual
-        ~unknown_option () throw ();
+        ~unknown_option () noexcept;
 
         unknown_option (const std::string& option);
 
@@ -105,7 +105,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string option_;
@@ -115,7 +115,7 @@ namespace build2
       {
         public:
         virtual
-        ~unknown_argument () throw ();
+        ~unknown_argument () noexcept;
 
         unknown_argument (const std::string& argument);
 
@@ -126,7 +126,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string argument_;
@@ -136,7 +136,7 @@ namespace build2
       {
         public:
         virtual
-        ~missing_value () throw ();
+        ~missing_value () noexcept;
 
         missing_value (const std::string& option);
 
@@ -147,7 +147,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string option_;
@@ -157,7 +157,7 @@ namespace build2
       {
         public:
         virtual
-        ~invalid_value () throw ();
+        ~invalid_value () noexcept;
 
         invalid_value (const std::string& option,
                        const std::string& value,
@@ -176,7 +176,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string option_;
@@ -191,14 +191,14 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
       };
 
       class LIBBUILD2_SYMEXPORT file_io_failure: public exception
       {
         public:
         virtual
-        ~file_io_failure () throw ();
+        ~file_io_failure () noexcept;
 
         file_io_failure (const std::string& file);
 
@@ -209,7 +209,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string file_;
@@ -219,7 +219,7 @@ namespace build2
       {
         public:
         virtual
-        ~unmatched_quote () throw ();
+        ~unmatched_quote () noexcept;
 
         unmatched_quote (const std::string& argument);
 
@@ -230,7 +230,7 @@ namespace build2
         print (::std::ostream&) const;
 
         virtual const char*
-        what () const throw ();
+        what () const noexcept;
 
         private:
         std::string argument_;


### PR DESCRIPTION
They are deprecated in C++11 and removed in C++17.

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3051.html