### PR TITLE
Add experimental support for Circle: (The Next) C++ Compiler

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,9 +1,9 @@
 # file      : buildfile
 # license   : MIT; see accompanying LICENSE file
 
-./: {*/ -build/ -config/ -old-tests/}                    \
-    doc{INSTALL NEWS README} legal{LICENSE AUTHORS}      \
-    file{INSTALL.cli bootstrap* config.guess config.sub} \
+./: {*/ -build/ -config/ -old-tests/ -doc/} \
+    doc{NEWS README} legal{LICENSE AUTHORS} \
+    file{INSTALL.cli bootstrap*}            \
     manifest
 
 # Don't install tests or the INSTALL file.

--- a/libbuild2/cc/compile-rule.cxx
+++ b/libbuild2/cc/compile-rule.cxx
@@ -372,12 +372,7 @@ namespace build2
             {
               bool obj (x_objective (md.src));
 
-              o1 = "-x";
-              switch (x_lang)
-              {
-              case lang::c:   o2 = obj ? "objective-c"   : "c";   break;
-              case lang::cxx: o2 = obj ? "objective-c++" : "c++"; break;
-              }
+              o1 = "-c";
               break;
             }
           case unit_type::module_intf:
@@ -404,13 +399,13 @@ namespace build2
                   if (h)
                     args.push_back ("-fmodule-header");
 
-                  o1 = "-x";
-                  o2 = h ? "c++-header" : "c++";
+                  o1 = "-c";
+                  o2 = h ? "c++-header" : "";
                   break;
                 }
               case compiler_type::clang:
                 {
-                  o1 = "-x";
+                  o1 = "-c";
                   o2 =  h ? "c++-header" : "c++-module";
                   break;
                 }
@@ -7189,7 +7184,6 @@ namespace build2
           {
             switch (ctype)
             {
-            case compiler_type::circle:
             case compiler_type::gcc:
               {
                 // Output module file is specified in the mapping file, the

--- a/libbuild2/cc/compile-rule.cxx
+++ b/libbuild2/cc/compile-rule.cxx
@@ -3479,8 +3479,10 @@ namespace build2
 
               // See perform_update() for details on the choice of options.
               //
-              if (!find_option_prefix ("-finput-charset=", args))
-                args.push_back ("-finput-charset=UTF-8");
+              // @@ FIXME: circle doesn't support -finput-charset.
+              //
+              // if (!find_option_prefix ("-finput-charset=", args))
+              //   args.push_back ("-finput-charset=UTF-8");
 
               if (ot == otype::s)
               {
@@ -3607,10 +3609,13 @@ namespace build2
               }
               else
               {
-                args.push_back ("-MQ");
-                args.push_back ("^");
-                args.push_back ("-M");
-                args.push_back ("-MG"); // Treat missing headers as generated.
+                if (ctype != compiler_type::circle)
+                {
+                  args.push_back ("-MQ");
+                  args.push_back ("^");
+                  args.push_back ("-M");
+                  args.push_back ("-MG"); // Treat missing headers as generated.
+                }
                 gen = args_gen = true;
               }
 
@@ -4994,8 +4999,10 @@ namespace build2
 
               // See perform_update() for details on the choice of options.
               //
-              if (!find_option_prefix ("-finput-charset=", args))
-                args.push_back ("-finput-charset=UTF-8");
+              // @@ FIXME: circle doesn't support --finput-charset=
+              //
+              // if (!find_option_prefix ("-finput-charset=", args))
+              //  args.push_back ("-finput-charset=UTF-8");
 
               if (ot == otype::s)
               {
@@ -7055,8 +7062,10 @@ namespace build2
           //
           // Note that early versions of Clang only recognize uppercase UTF-8.
           //
-          if (!find_option_prefix ("-finput-charset=", args))
-            args.push_back ("-finput-charset=UTF-8");
+          // @@ FIXME: Circle doesn't support -finput-charset.
+          //
+          // if (!find_option_prefix ("-finput-charset=", args))
+          //  args.push_back ("-finput-charset=UTF-8");
 
           if (ot == otype::s)
           {

--- a/libbuild2/cc/compile-rule.cxx
+++ b/libbuild2/cc/compile-rule.cxx
@@ -921,6 +921,7 @@ namespace build2
             e += (ut != unit_type::non_modular ? "ifc" : o);
             break;
           }
+        case compiler_type::circle:
         case compiler_type::icc:
           {
             assert (ut == unit_type::non_modular);
@@ -3056,6 +3057,7 @@ namespace build2
           //pp = "/C";
           break;
         }
+      case compiler_type::circle:
       case compiler_type::icc:
         break;
       }
@@ -6567,6 +6569,7 @@ namespace build2
 
           break;
         }
+      case compiler_type::circle:
       case compiler_type::clang:
       case compiler_type::msvc:
       case compiler_type::icc:
@@ -6735,6 +6738,7 @@ namespace build2
           }
           break;
         }
+      case compiler_type::circle:
       case compiler_type::icc:
         break;
       }
@@ -7001,7 +7005,7 @@ namespace build2
           // @@ MOD: TODO deal with absent relo.
           //
           if (find_options ({"/Zi", "/ZI", "-Zi", "-ZI"}, args))
-          {
+          { 
             if (fc)
               args.push_back ("/Fd:");
             else
@@ -7147,6 +7151,7 @@ namespace build2
 
                 break;
               }
+            case compiler_type::circle:
             case compiler_type::gcc:
             case compiler_type::msvc:
             case compiler_type::icc:
@@ -7184,6 +7189,7 @@ namespace build2
           {
             switch (ctype)
             {
+            case compiler_type::circle:
             case compiler_type::gcc:
               {
                 // Output module file is specified in the mapping file, the
@@ -7271,6 +7277,7 @@ namespace build2
                 //
                 break;
               }
+            case compiler_type::circle: // @@ TODO: ?
             case compiler_type::icc:
               break; // Compile as normal source for now.
             case compiler_type::msvc:
@@ -7363,6 +7370,7 @@ namespace build2
             //
             break;
           }
+        case compiler_type::circle: // ?
         case compiler_type::icc:
           assert (false);
         }
@@ -7538,6 +7546,7 @@ namespace build2
       case compiler_type::gcc:   extras = {".d", pext, cpext.c_str (), ".t"};           break;
       case compiler_type::clang: extras = {".d", pext, cpext.c_str ()};                 break;
       case compiler_type::msvc:  extras = {".d", pext, cpext.c_str (), ".idb", ".pdb"}; break;
+      case compiler_type::circle:
       case compiler_type::icc:   extras = {".d"};                                       break;
       }
 

--- a/libbuild2/cc/gcc.cxx
+++ b/libbuild2/cc/gcc.cxx
@@ -229,8 +229,12 @@ namespace build2
       // It's highly unlikely not to have any system directories. More likely
       // we misinterpreted the compiler output.
       //
+      //
+      // @@ TODO: Circle is able to determine the compiler system header by
+      // itself, but since "b" does not know this, we get a false positive
+      // here.
       if (r.empty ())
-        fail << "unable to extract " << x_lang << " compiler system header "
+        info << "unable to extract " << x_lang << " compiler system header "
              << "search paths";
 
       return make_pair (move (r), size_t (0));
@@ -269,7 +273,11 @@ namespace build2
 
       cstrings args {xc.recall_string ()};
       append_options (args, rs, x_mode);
-      args.push_back ("-print-search-dirs");
+
+      // @@ FIXME: circle doesn't know about -print-search-dirs
+      //
+      args.push_back ("-print-paths");
+      args.push_back ("cxx");
       args.push_back (nullptr);
 
       process_env env (xc);
@@ -326,8 +334,12 @@ namespace build2
 
       run_finish (args, pr, 2 /* verbosity */);
 
+      // @@ TODO: Circle is able to determine the compiler system library by
+      // itself, but since "b" does not know this, we get a false positive
+      // here.
+      //
       if (l.empty ())
-        fail << "unable to extract " << x_lang << " compiler system library "
+        info << "unable to extract " << x_lang << " compiler system library "
              << "search paths";
 
       // Now the fun part: figuring out which delimiter is used. Normally it

--- a/libbuild2/cc/gcc.cxx
+++ b/libbuild2/cc/gcc.cxx
@@ -116,8 +116,7 @@ namespace build2
         return nullptr;
       };
 
-      args.push_back ("-x");
-      args.push_back (langopt ());
+      args.push_back ("-c");
       args.push_back ("-v");
       args.push_back ("-E");
       args.push_back ("-");

--- a/libbuild2/cc/guess.cxx
+++ b/libbuild2/cc/guess.cxx
@@ -166,12 +166,7 @@ namespace build2
       if (c_co != nullptr) append_options (args, *c_co);
       if (x_co != nullptr) append_options (args, *x_co);
       append_options (args, x_mo);
-      args.push_back ("-x");
-      switch (xl)
-      {
-      case lang::c:   args.push_back ("c");   break;
-      case lang::cxx: args.push_back ("c++"); break;
-      }
+      args.push_back ("-c");
       args.push_back ("-E");
       args.push_back ("-");  // Read stdin.
       args.push_back (nullptr);
@@ -2187,12 +2182,7 @@ namespace build2
       }
       else
       {
-        args.push_back ("-x");
-        switch (xl)
-        {
-        case lang::c:   args.push_back ("c");   break;
-        case lang::cxx: args.push_back ("c++"); break;
-        }
+        args.push_back ("-c");
       }
 
       args.push_back ("-v");

--- a/libbuild2/cc/guess.hxx
+++ b/libbuild2/cc/guess.hxx
@@ -35,7 +35,8 @@ namespace build2
       gcc = 1, // 0 value represents invalid type.
       clang,
       msvc,
-      icc
+      icc,
+      circle
       // Update compiler_id(string) and to_string() if adding a new type.
     };
 

--- a/libbuild2/cc/link-rule.cxx
+++ b/libbuild2/cc/link-rule.cxx
@@ -3925,6 +3925,7 @@ namespace build2
             }
             break;
           }
+        case compiler_type::circle:
         case compiler_type::msvc:
         case compiler_type::icc:
           break;

--- a/libbuild2/cxx/init.cxx
+++ b/libbuild2/cxx/init.cxx
@@ -435,6 +435,7 @@ namespace build2
 
               break;
             }
+          case compiler_type::circle:
           case compiler_type::icc:
             break; // No modules support yet.
           }

--- a/libbuild2/cxx/init.cxx
+++ b/libbuild2/cxx/init.cxx
@@ -308,6 +308,8 @@ namespace build2
 
                 break;
               }
+            case compiler_type::circle:
+              break;
             default:
               assert (false);
             }


### PR DESCRIPTION
> *Circle describes a path for evolving C++ to meet the needs of institutional users. The versioning mechanism that accommodated the development of the features above will also accommodate research into critically important areas like memory safety. Rather than insisting on a one-size-fit's-all approach to language development, project leads can opt into collections of features that best target their projects' needs.*

This PR adds pre-emptive support for Circle to the build2 build system. This Patch is a draft, meaning it is not ready for consumption and only serve as a starting point to play around. 

```
cxx @/home/wroy/Documents/hello/hello/
  cxx        circle@/usr/local/bin/circle
  id         circle
  version    171
  major      0
  minor      0
  patch      0
  signature  circle version 1.0.0-171
  checksum   c15754f34e1bb4f05be569a50ed60067a5a368f5f1d17c321915d3919abb7ab2
  target     x86_64-linux-gnu (x86_64-pc-linux-gnu)
  runtime    libgcc
  stdlib     libstdc++
  c stdlib   
circle -x c++ /home/wroy/Documents/hello/hello/hello.cxx
circle -E -x c++ /home/wroy/Documents/hello/hello/hello.cxx
circle -o hello -c -x c++ /home/wroy/Documents/hello/hello/hello.cxx
circle -o x hello
``` 

> **Warning**
>
> I intend to revisit this PR from the ground up when Circle achieves greater maturity. In the interim, you can use this patch to provide feedback about Circle and explore its capabilities. Please be aware that some features may not function perfectly at this time.
