### PR TITLE
Dedupes pkg-config -I flags

### DIFF
--- a/libbuild2/cc/pkgconfig.cxx
+++ b/libbuild2/cc/pkgconfig.cxx
@@ -321,6 +321,12 @@ namespace build2
       {
         strings pops;
 
+        // Dedupes pkg-config -I flags by storing unique flags in a set with an
+        // average O(1) time complexity. Note that this is non-static to avoid
+        // falsely affecting transitive dependencies as duplicates.
+        //
+        unordered_set<string> h;
+
         bool arg (false);
         for (auto& o: pc.cflags (la))
         {
@@ -328,7 +334,7 @@ namespace build2
           {
             // Can only be an argument for -I, -D, -U options.
             //
-            pops.push_back (move (o));
+            if (h.insert (o).second) pops.push_back (move (o));
             arg = false;
             continue;
           }
@@ -340,7 +346,7 @@ namespace build2
           if (n >= 2 &&
               o[0] == '-' && (o[1] == 'I' || o[1] == 'D' || o[1] == 'U'))
           {
-            pops.push_back (move (o));
+            if (h.insert (o).second) pops.push_back (move (o));
             arg = (n == 2);
             continue;
           }

--- a/libbuild2/types.hxx
+++ b/libbuild2/types.hxx
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <functional>       // hash, function, reference_wrapper
 #include <initializer_list>
+#include <unordered_set>
 
 #include <atomic>
 


### PR DESCRIPTION
Dedupes pkg-config -I flags by storing unique flags in a set with an average O(1) time complexity. Note that `h` is non-static to avoid falsely affecting transitive dependencies as duplicates.

Fix https://github.com/build2/build2/issues/245
Fix https://github.com/build2/build2/issues/265
Fix https://github.com/build2/build2/issues/237