### PR TITLE
Fixed a typo in manual

### DIFF
--- a/doc/manual.cli
+++ b/doc/manual.cli
@@ -3231,7 +3231,7 @@ configuration inheritance. As an example, let's configure the above bundled
 \
 $ b configure: hello/ config.cxx=clang++ config.cxx.coptions=-g
 
-$ b tree
+$ tree
 hello/
 ├── build/
 │   ├── config.build


### PR DESCRIPTION
A typo fix:
```
$ b tree
hello/
├── build/
│   ├── config.build
│   └── ...
├── libhello/
│   ├── build/
│   │   ├── config.build
│   │   └── ...
│   └── ...
└── ...
```

Most probably should be just `$ tree` .