### PR TITLE
Fixing objects not created from module pcm files when compiling with clang

### DIFF
--- a/libbuild2/cc/compile-rule.cxx
+++ b/libbuild2/cc/compile-rule.cxx
@@ -946,7 +946,9 @@ namespace build2
         //
         // Note: ut is still unrefined.
         //
-        if (ut == unit_type::module_intf && cast_true<bool> (t[b_binless]))
+        if ((ut == unit_type::module_intf      ||
+             ut == unit_type::module_intf_part ||
+             ut == unit_type::module_impl_part) && cast_true<bool> (t[b_binless]))
         {
           // The module interface unit can be the same as an implementation
           // (e.g., foo.mxx and foo.cxx) which means obj*{} targets could
@@ -7759,7 +7761,10 @@ namespace build2
       //
       // @@ MODPART: Clang (all of this is probably outdated).
       //
-      if (ctype == compiler_type::clang && ut == unit_type::module_intf)
+      if (ctype == compiler_type::clang     &&
+         (ut == unit_type::module_intf      ||
+          ut == unit_type::module_intf_part ||
+          ut == unit_type::module_impl_part))
       {
         // Adjust the command line. First discard everything after -o then
         // build the new "tail".


### PR DESCRIPTION
While playing a bit with `clang` and C++ modules I noticed that `build2` can work the clang modules very well.
I found that module interface partitions and module implementation partition were not generating `.o` files, while module interface units were.
The background and reason for is that `clang` behaves differently compared to `gcc` and requires two compiler invocations.
The PR just adds the specific cases of module interface and implementation partitions to create `.o` in addition to `.pcm`.