### PR TITLE
Don't push -fmodules-ts starting with clang/llvm 17

### DIFF
--- a/libbuild2/cxx/init.cxx
+++ b/libbuild2/cxx/init.cxx
@@ -457,7 +457,7 @@ namespace build2
                 // See also:
                 // https://github.com/llvm/llvm-project/commit/612f3ac
                 //
-                if (mj < 17)
+                if (mj < 16)
                   mode.push_back ("-fmodules-ts"); // For the hack to work.
 
                 modules = true;

--- a/libbuild2/cxx/init.cxx
+++ b/libbuild2/cxx/init.cxx
@@ -449,7 +449,17 @@ namespace build2
               if (modules.value)
               {
                 prepend ("-D__cpp_modules=201704"); // p0629r0
-                mode.push_back ("-fmodules-ts"); // For the hack to work.
+
+                // -fmodules-ts is removed in clang/llvm 17 and deprecated in
+                // clang/llvm 16. We still hold onto it for now, as some
+                // distributions (e.g., Debian) still ship earlier versions.
+                //
+                // See also:
+                // https://github.com/llvm/llvm-project/commit/612f3ac
+                //
+                if (mj < 17)
+                  mode.push_back ("-fmodules-ts"); // For the hack to work.
+
                 modules = true;
               }
 


### PR DESCRIPTION
It became obsolete in clang/llvm 16 and was officially removed starting with clang/llvm 17.

https://github.com/llvm/llvm-project/commit/612f3ac