### PR TITLE
Update `line_char` to tolerate `<regex>` round-trip conversions

### DIFF
--- a/libbuild2/script/regex.cxx
+++ b/libbuild2/script/regex.cxx
@@ -52,7 +52,7 @@ namespace build2
         // @@ How can we allow anything for basic_regex but only subset
         //    for our own code?
         //
-        const char ex[] = "pn\n\r";
+        const char ex[] = "pn\n\r\a";
 
         assert (c == 0  || // Null character.
 
@@ -72,7 +72,7 @@ namespace build2
 
                   // libstdc++ look-ahead tokens, newline chars.
                   //
-                  string::traits_type::find (ex, 4, c) != nullptr)));
+                  string::traits_type::find (ex, 5, c) != nullptr)));
       }
 
       template <typename S>

--- a/libbuild2/script/regex.hxx
+++ b/libbuild2/script/regex.hxx
@@ -205,8 +205,7 @@ namespace build2
         explicit
         operator T () const
         {
-          assert (type () == line_type::special);
-          return static_cast<T> (special ());
+          return static_cast<T> (type () == line_type::special ? special () : '\a'); // BELL.
         }
       };
 


### PR DESCRIPTION
In MSVC's STL, we recently merged https://github.com/microsoft/STL/pull/5592 to remove non-Standard `_Uelem` machinery from the `<regex>` parser. This broke build2, which we regularly build in our "Real World Code" test suite with development versions of MSVC.

The issue is that build2's use of a custom character type leads to an extremely brittle dependence on the internal implementation of `<regex>`, as indicated by the numerous comments in your codebase about the details of what MSVC's STL and libstdc++ happened to be doing. While parsing a regex, we need to compare its characters against escape sequences like `R"(\bcats\b)"` (word boundary assertions, for example). Our recent PR did this by constructing the user-defined character type from `char`s like `'b'`. This is rejected by build2's assertions.

While I believe that build2 should strongly consider refactoring this entire code, I've created an additional MSVC STL PR that adjusts our comparisons to avoid requesting larger changes from build2: https://github.com/microsoft/STL/pull/5675. Instead of constructing user-defined character types from `char` (and then comparing homogeneously), we'll directly compare against `char`. This is less theoretically pure, but uses build2's heterogeneous comparison operators, avoiding most problems.

However, we still need to detect whether user-defined character types can round-trip through `char` (to avoid being confused by truncation). This PR here is a small change to support that. In `regex.hxx`, it applies what `operator char ()` is already doing, to `operator T ()`. This allows all user-defined characters to be implicitly converted, returning `\a` (BELL) for your "non-special" type. (MSVC's STL needs this now because we sometimes convert to types other than `char` specifically, as part of our `_Uelem` removal/overhaul.) Then in `regex.cxx`, I'm adjusting `line_char`'s constructor to accept this `\a` (BELL) character, to accept round-tripping without asserting.

This appears to pass build2's tests locally on my machine, with the updated MSVC STL.