### PR TITLE
Add a minimum required stack size  

### DIFF
--- a/bx/bx.cli
+++ b/bx/bx.cli
@@ -124,7 +124,12 @@ namespace build2
        than a predefined limit (64MB on 64-bit systems and 32MB on 32-bit
        ones) and caps it to a more sensible value (8MB) if that's the case.
        This option allows you to override this check with the special zero
-       value indicating that the main thread stack size should be used as is."
+       value indicating that the main thread stack size should be used as is.
+       A stack size below 1MB may cause segmention faults so the driver checks 
+       if the stack size is less than 1MB and clamps it to 1MB. This option can
+       be used to override this behavior, and set the stack size to a lower 
+       value. Anything below ~500KB is almost certianly going to seg-fault if 
+       multithreading is enabled."
     }
 
     string --pager // String to allow empty value.

--- a/libbuild2/scheduler.cxx
+++ b/libbuild2/scheduler.cxx
@@ -999,6 +999,7 @@ namespace build2
     // at LIBBUILD2_DEFAULT_STACK_SIZE (default: 8MB). This can also be
     // overridden at runtime with the --max-stack build2 driver option
     // (remember to update its documentation of changing anything here).
+    // 
     //
     // On Windows the stack size is the same for all threads and is customized
     // at the linking stage (see build2/buildfile). Thus neither *_STACK_SIZE
@@ -1027,6 +1028,13 @@ namespace build2
 
 #ifndef LIBBUILD2_SANE_STACK_SIZE
 #  define LIBBUILD2_SANE_STACK_SIZE (sizeof(void*) * LIBBUILD2_DEFAULT_STACK_SIZE)
+#endif
+
+  // The true minimum might be as small as 560KB but why risk having to run 
+  // into stack size issues again?  
+  //
+#ifndef LIBBUILD2_MIN_STACK_SIZE
+#  define LIBBUILD2_MIN_STACK_SIZE 1048576 // 1MB
 #endif
 
     // Auto-deleter.
@@ -1098,7 +1106,7 @@ namespace build2
 #endif
     }
 
-    // Cap the size if necessary.
+    // Clamp the size if necessary.
     //
     if (max_stack)
     {
@@ -1107,6 +1115,8 @@ namespace build2
     }
     else if (stack_size > LIBBUILD2_SANE_STACK_SIZE)
       stack_size = LIBBUILD2_DEFAULT_STACK_SIZE;
+    else if (stack_size < LIBBUILD2_MIN_STACK_SIZE)
+      stack_size = LIBBUILD2_MIN_STACK_SIZE;
 
     pthread_attr_t attr;
     int r (pthread_attr_init (&attr));
@@ -1122,7 +1132,7 @@ namespace build2
 
     if (r != 0)
       throw_system_error (r);
-
+    
     r = pthread_attr_setstacksize (&attr, stack_size);
 
     if (r != 0)

--- a/libbuild2/scheduler.cxx
+++ b/libbuild2/scheduler.cxx
@@ -982,15 +982,16 @@ namespace build2
 
     } g {&l, helpers_, starting_};
 
-    // For some platforms/compilers the default stack size for newly created
-    // threads may differ from that of the main thread. Here are the default
-    // main/new thread sizes (in KB) for some of them:
+    // For some platforms/compilers/libraries the default stack size for newly
+    // created threads may differ from that of the main thread. Here are the 
+    // default main/new thread sizes (in KB) for some of them:
     //
     // Linux   :   8192 / 8196
     // FreeBSD : 524288 / 2048
     // MacOS   :   8192 /  512
     // MinGW   :   2048 / 2048
     // VC      :   1024 / 1024
+    // Musl    :    128 /  128
     //
     // Provided the main thread size is less-equal than
     // LIBBUILD2_SANE_STACK_SIZE (which defaults to
@@ -998,7 +999,9 @@ namespace build2
     // thread stack is the same as for the main thread. Otherwise, we cap it
     // at LIBBUILD2_DEFAULT_STACK_SIZE (default: 8MB). This can also be
     // overridden at runtime with the --max-stack build2 driver option
-    // (remember to update its documentation of changing anything here).
+    // (remember to update its documentation of changing anything here). We 
+    // also make sure that the stack size is at least 1MB, Unless --max-stack
+    // is smaller than 1MB.
     // 
     //
     // On Windows the stack size is the same for all threads and is customized
@@ -1108,15 +1111,19 @@ namespace build2
 
     // Clamp the size if necessary.
     //
-    if (max_stack)
+    if (stack_size < LIBBUILD2_MIN_STACK_SIZE)
+      stack_size = LIBBUILD2_MIN_STACK_SIZE;
+
+    // Note that --max-stack can be used set the stack size below 
+    // LIBBUILD2_MIN_STACK_SIZE
+    //
+    if (max_stack) 
     {
       if (*max_stack != 0 && stack_size > *max_stack)
         stack_size = *max_stack;
     }
     else if (stack_size > LIBBUILD2_SANE_STACK_SIZE)
       stack_size = LIBBUILD2_DEFAULT_STACK_SIZE;
-    else if (stack_size < LIBBUILD2_MIN_STACK_SIZE)
-      stack_size = LIBBUILD2_MIN_STACK_SIZE;
 
     pthread_attr_t attr;
     int r (pthread_attr_init (&attr));


### PR DESCRIPTION
Currently drafted because I haven't checked if I need to updated the documentation and other things like libbutl maybe

This PR adds code to check if the stack size is less than a predefined minimum (I settled on 1MB) and if so, sets the stack size to the minimum
This PR will hopefull fix issue #438, and fixes a very similar (if not the exact same) issue on my system.
