### PR TITLE
Fix missing rpath for shared libs required transitively through static libs

### DIFF
--- a/libbuild2/cc/link-rule.cxx
+++ b/libbuild2/cc/link-rule.cxx
@@ -2841,10 +2841,11 @@ namespace build2
 
       auto imp = [link] (const target& l, bool la)
       {
-        // If we are not rpath-link'ing, then we only need to rpath interface
-        // libraries (they will include rpath's for their implementations)
-        // Otherwise, we have to do this recursively. In both cases we also
-        // want to see through utility libraries.
+        // If we are not rpath-link'ing, we recurse into static libraries
+        // (which cannot carry rpath themselves) but not into shared libraries
+        // (which already embed rpath for their own implementations).
+        // Otherwise (rpath-link), we have to do this recursively. In both
+        // cases we also want to see through utility libraries.
         //
         // The rpath-link part is tricky: ideally we would like to get only
         // implementations and only of shared libraries. We are not interested
@@ -2855,7 +2856,7 @@ namespace build2
         // except for some noise on the command line.
         //
         //
-        return (link ? !la : false) || l.is_a<libux> ();
+        return (link ? !la : la) || l.is_a<libux> ();
       };
 
       // Package the data to keep within the 2-pointer small std::function


### PR DESCRIPTION
Fixes: #528

When an exe links a static library (`liba`) that itself depends on a shared
library (`libs`), the shared library's directory was not added to the exe's
rpath. This caused runtime failures (`"error while loading shared libraries"`)
because the rpath traversal never recursed into static library implementation
dependencies.

The fix changes the `rpath_libraries()` `imp` lambda from returning `false` (never
recurse) to returning `la` (recurse into static libs, not shared libs) when
building rpath (`link=false`). This should be correct because:

- Static libs cannot carry rpath themselves, so any shared libs they depend
  on must be rpath'd directly by the consumer.
- Shared libs already embed rpath for their own dependencies, so not recursing
  into them is correct and unchanged.

The rpath-link path (`link=true`) is unaffected, it already recurses into shared
libs (`!la`) and the logic there is unchanged. The `is_a<libux>()` path is also
unchanged. The only new behavior is recursing into `liba` implementation deps
when computing rpath, adding rpath entries for shared libs that are direct
link dependencies of the static lib (and therefore potentially required at
runtime).