### PR TITLE
Fix MSVC C11, C17, and C18 standard flags (#553)

### DIFF
--- a/libbuild2/c/init.cxx
+++ b/libbuild2/c/init.cxx
@@ -124,10 +124,16 @@ namespace build2
 
             if      (stdcmp ("99") && mj >= 16) // Since VS2010/10.0.
               ;
-            else if ((stdcmp ("11") ||
-                      stdcmp ("17") ||
-                      stdcmp ("18")) && mj >= 18) // Since VS????/11.0.
-              ;
+            else if (stdcmp ("11") &&
+                      (mj > 19 || (mj == 19 && mi >= 27))) // Since MSVC 19.27
+            {
+              mode.insert (mode.begin (), "/std:c11");
+            }
+            else if (stdcmp("17", "18") &&
+                      (mj > 19 || (mj == 19 && mi >= 28))) // Since MSVC 19.28
+            {
+              mode.insert (mode.begin (), "/std:c17"); // MSVC does not support C18
+            }
             else if (stdcmp ("23", "2x") &&
                      (mj > 19 || (mj == 19 && mi >= 39))) // Since 17.9.
             {


### PR DESCRIPTION
Fixes #553

Enable the corresponding C standard flags for MSVC:
- C11 will become `/std:c11`
- C17 and C18 will become `/std:c17`

C18 is mapped to `/std:c17` because MSVC does not provide a separate `/std:c18` option.

The flags are enabled based on the MSVC compiler version.
